### PR TITLE
Store raw function code in the AST

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,6 +42,7 @@ pub struct Function {
     pub name: String,
     pub parameters: Vec<String>,
     pub statements: Vec<Statement>,
+    pub statements_code: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -302,6 +302,7 @@ mod tests {
                         ))],
                         else_statements: vec![],
                     })],
+                    statements_code: String::new(),
                 })],
             })
             .unwrap();
@@ -324,6 +325,7 @@ mod tests {
                     statements: vec![ast::Statement::Return(ast::Expression::Ident(
                         "age".to_string(),
                     ))],
+                    statements_code: String::new(),
                 })],
             })
             .unwrap();
@@ -357,6 +359,7 @@ mod tests {
                         Box::new(ast::Expression::Ident("error".to_string())),
                         vec![ast::Expression::String("Something went wrong".to_string())],
                     ))],
+                    statements_code: String::new(),
                 })],
             })
             .unwrap();
@@ -464,6 +467,7 @@ mod tests {
                                 Box::new(ast::Expression::Ident("amount".to_string())),
                             )),
                         ],
+                        statements_code: String::new(),
                     }),
                 ],
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ mod tests {
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements }) if name == "get_age" && parameters.len() == 0 && statements.len() == 1)
+            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code }) if name == "get_age" && parameters.len() == 0 && statements.len() == 1 && statements_code == "return 42;")
         );
 
         let function = match &collection.items[0] {

--- a/src/spacetime.lalrpop
+++ b/src/spacetime.lalrpop
@@ -150,10 +150,11 @@ pub ParameterList: Vec<String> = {
 };
 
 pub Function: Function = {
-    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <s:Statement*> "}" => Function {
+    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
         statements: s,
+        statements_code: input[l..r].to_string(),
     },
 };
 


### PR DESCRIPTION
This adds a `statements_code` field to the Function node, which is the code of the inner function block, like `return 42;`